### PR TITLE
Trying to make swaps work again

### DIFF
--- a/src/components/SwapForm/Form.tsx
+++ b/src/components/SwapForm/Form.tsx
@@ -9,7 +9,7 @@ import { useState, useEffect } from 'react';
 import { useAccount, usePublicClient, useWalletClient } from 'wagmi';
 import axios from 'axios';
 import { signOrder, signPermit } from '../../eip712/signer';
-import { getGaslessNonce, getTokenNonce, Intent, Order, Permit } from '../../utils/utils';
+import { getGaslessNonce, getTokenNonce, Intent, GaslessCrossChainOrder, Permit } from '../../utils/utils';
 import bs58check from 'bs58check';
 import { UserRejectedRequestError } from 'viem';
 import { configuration } from '../../config/config';
@@ -385,7 +385,7 @@ export default function SwapForm() {
                 to: decodedTronAddress as `0x${string}`,
                 outputAmount: outputValue,
             };
-            const order: Order = {
+            const order: GaslessCrossChainOrder = {
                 originSettler: contractAddress,
                 user: address,
                 nonce: gaslessNonce,
@@ -395,7 +395,7 @@ export default function SwapForm() {
                 intent: intent,
             };
             console.log(order);
-            const orderSignature = await signOrder(walletClient, chainId, contractAddress, order);
+            const orderSignature = await signOrder(walletClient, publicClient, chainId, contractAddress, order);
 
             await axios.post(`${configuration.urls.backend}/intents/swap`, {
                 userAddress: address,
@@ -415,7 +415,7 @@ export default function SwapForm() {
                 fillDeadline: order.fillDeadline.toString(),
                 intent: {
                     refundBeneficiary: intent.refundBeneficiary,
-                    inputs: intent.inputs.map(input => ({
+                    inputs: intent.inputs.map((input: { token: `0x${string}`; amount: bigint }) => ({
                         token: input.token,
                         amount: input.amount.toString()
                     })),

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -245,6 +245,10 @@ export function encodeIntent(intent: Intent): `0x${string}` {
         intent.outputAmount,
     ]);
 
-    const offsetEncodedIntent = encodedIntent;
+    const offsetEncodedIntent = (
+        '0x0000000000000000000000000000000000000000000000000000000000000020' +
+        encodedIntent.slice(2)
+    ) as `0x${string}`;
+
     return offsetEncodedIntent;
 }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -245,10 +245,6 @@ export function encodeIntent(intent: Intent): `0x${string}` {
         intent.outputAmount,
     ]);
 
-    const offsetEncodedIntent = (
-        '0x0000000000000000000000000000000000000000000000000000000000000020' +
-        encodedIntent.slice(2)
-    ) as `0x${string}`;
-
+    const offsetEncodedIntent = encodedIntent;
     return offsetEncodedIntent;
 }


### PR DESCRIPTION
After backend refactoring (done right on the main branch), the swaps no longer work. Specifically, the problem is in the invalid signature—when the backend tries to send the permitAndOpenFor call to the contract, it reverts with 0x815e1d64 (InvalidSigner) error. As the signer is indeed valid, the bug is in the invalid payload being signed. As of now, the root of the error is quite isolated:

- Given the same POST payload, the call reverts both on backend and on a simple Python script (in untron-intents repo), thus the problem is probably on frontend and not the new backend

- On frontend, local messageHash generation (messageHash is what the signature is verified against) is equivalent to that on the contract (_messageHash() public view function). Thus, generation of everything else (order IDs, ABI encoding, etc) is also equivalent to what the contract expects. However, we do not ask to sign the hash itself, but the typed data that we also hash using our implementation to check equivalence. Therefore, I believe that the problem might be in "walletClient.signTypedData"—maybe it hashes our typed data incorrectly which results in the messageHash different from what we expect. Unfortunately, currently I have no idea how to debug this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new order type, `GaslessCrossChainOrder`, enhancing the swap functionality.
	- Improved order signing process with additional error handling and logging.
  
- **Bug Fixes**
	- Enhanced error handling for invalid Tron address decoding and fee data retrieval failures.

- **Documentation**
	- Updated import statements and function signatures to reflect the new order structure and parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->