### PR TITLE
Fix npm build process

### DIFF
--- a/app/api/untron/[...path]/route.ts
+++ b/app/api/untron/[...path]/route.ts
@@ -7,12 +7,9 @@ function buildUpstreamUrl(pathSegments: string[], search: string) {
   return `${UPSTREAM_BASE}/${joined}${search}`;
 }
 
-export async function GET(req: NextRequest, {
-  params,
-}: {
-  params: { path: string[] };
-}) {
-  const upstream = buildUpstreamUrl(params.path, new URL(req.url).search);
+export async function GET(req: NextRequest, { params }: { params: Promise<{ path: string[] }> }) {
+  const { path } = await params;
+  const upstream = buildUpstreamUrl(path, new URL(req.url).search);
   const resp = await fetch(upstream, {
     method: "GET",
     // pass along no-cache to avoid stale data during polling
@@ -25,12 +22,9 @@ export async function GET(req: NextRequest, {
   });
 }
 
-export async function POST(req: NextRequest, {
-  params,
-}: {
-  params: { path: string[] };
-}) {
-  const upstream = buildUpstreamUrl(params.path, "");
+export async function POST(req: NextRequest, { params }: { params: Promise<{ path: string[] }> }) {
+  const { path } = await params;
+  const upstream = buildUpstreamUrl(path, "");
   const body = await req.text();
   const resp = await fetch(upstream, {
     method: "POST",


### PR DESCRIPTION
Update API route handlers to correctly type and await `params` for Next.js 15 compatibility, fixing `npm run build`.

Next.js 15 introduced a type-check for API route signatures, requiring `params` to be treated as a `Promise` and awaited. This PR updates the `GET` and `POST` handlers to conform to this new signature, resolving build failures.

---

[Open in Web](https://www.cursor.com/agents?id=bc-c1473ca7-9e33-475d-8174-0f86fbb6b96b) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-c1473ca7-9e33-475d-8174-0f86fbb6b96b)